### PR TITLE
help needed: intermediate fix for Account Details (Profile Data) spinning forever

### DIFF
--- a/daemon/service/service.go
+++ b/daemon/service/service.go
@@ -1996,6 +1996,9 @@ func (s *Service) RequestSessionStatus() (
 		return apiCode, "", "", sessionStatus, srverrors.ErrorNotLoggedIn{}
 	}
 
+	// TODO: Vlad - disabling /session/status API calls
+	return 0, "/session/status request skipped", "", sessionStatus, fmt.Errorf("/session/status request skipped")
+
 	// if no connectivity - skip request (and activate _isWaitingToUpdateAccInfoChan)
 	if err := s.IsConnectivityBlocked(); err != nil {
 		s._isNeedToUpdateSessionInfo = true

--- a/daemon/service/service.go
+++ b/daemon/service/service.go
@@ -1896,6 +1896,7 @@ func (s *Service) ProfileData() (
 	// Not querying Profile Data if we're not logged in yet
 	session := s.Preferences().Session
 	if !session.IsLoggedIn() {
+		log.Error("we're not logged in yet, so not querying Profile Data (/user/profile API)")
 		return apiCode, nil, srverrors.ErrorNotLoggedIn{}
 	}
 

--- a/daemon/service/service.go
+++ b/daemon/service/service.go
@@ -1892,6 +1892,13 @@ func (s *Service) ProfileData() (
 		profileDataResponse *api_types.ProfileDataResponse
 	)
 	log.Debug("================================ Profile Data function Reached ================================")
+
+	// Not querying Profile Data if we're not logged in yet
+	session := s.Preferences().Session
+	if !session.IsLoggedIn() {
+		return apiCode, nil, srverrors.ErrorNotLoggedIn{}
+	}
+
 	profileDataResponse, err = s._api.ProfileData(s.Preferences().Session.Session)
 	return 200, profileDataResponse, err
 }

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -189,8 +189,8 @@ export default {
     qr.make();
     // this.$refs.qrcode.innerHTML = qr.createSvgTag(3, 10);
 
-    this.accountStatusRequest();
     this.profileData();
+    //this.accountStatusRequest();
   },
   methods: {
     async logOut() {

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -314,14 +314,14 @@ export default {
       );
     },
   },
-  watch: {
-    "$store.state.account.userDetails": {
-      handler(newValue) {
-        this.isProcessing = Object.keys(newValue).length === 0 ? true : false;
-      },
-      immediate: true, // Run the watcher immediately on component creation
-    },
-  },
+  // watch: {
+  //   "$store.state.account.userDetails": {
+  //     handler(newValue) {
+  //       this.isProcessing = Object.keys(newValue).length === 0 ? true : false;
+  //     },
+  //     immediate: true, // Run the watcher immediately on component creation
+  //   },
+  // },
 };
 </script>
 

--- a/ui/src/daemon-client/index.js
+++ b/ui/src/daemon-client/index.js
@@ -411,8 +411,8 @@ async function processResponse(response) {
 
       commitSession(obj.Session);
 
-      // request account status update every app start
-      if (store.getters["account/isLoggedIn"]) SessionStatus();
+      // request profile data update every app start
+      if (store.getters["account/isLoggedIn"]) ProfileData();
 
       if (obj.DisabledFunctions) {
         store.commit("disabledFunctions", obj.DisabledFunctions);
@@ -957,6 +957,9 @@ async function AccountInfo() {
 }
 
 async function ProfileData() {
+  // if (store.getters["account/isLoggedIn"]) {
+  //   return nil
+  // }
   let resp = await sendRecv({
     Command: daemonRequests.ProfileData,
   });

--- a/ui/src/daemon-client/index.js
+++ b/ui/src/daemon-client/index.js
@@ -411,9 +411,6 @@ async function processResponse(response) {
 
       commitSession(obj.Session);
 
-      // request profile data update every app start
-      if (store.getters["account/isLoggedIn"]) ProfileData();
-
       if (obj.DisabledFunctions) {
         store.commit("disabledFunctions", obj.DisabledFunctions);
         if (obj.DisabledFunctions.WireGuardError) {
@@ -944,6 +941,10 @@ async function Login(
 
   // if (resp.APIStatus === API_SUCCESS) commitSession(resp.Session);
 
+  if (resp.APIStatus === API_SUCCESS) {
+    ProfileData();
+  }
+
   // Returning whole response object (even in case of error)
   // it contains details about error
   return resp;
@@ -957,7 +958,7 @@ async function AccountInfo() {
 }
 
 async function ProfileData() {
-  // if (store.getters["account/isLoggedIn"]) {
+  // if (!store.getters["account/isLoggedIn"]) {
   //   return nil
   // }
   let resp = await sendRecv({

--- a/ui/src/ipc/main-listener.js
+++ b/ui/src/ipc/main-listener.js
@@ -175,8 +175,8 @@ ipcMain.handle(
   }
 );
 
-ipcMain.handle("renderer-request-ProfileData", async (event, pid, execCmd) => {
-  return await client.ProfileData(pid, execCmd);
+ipcMain.handle("renderer-request-ProfileData", async (event) => {
+  return await client.ProfileData();
 });
 
 ipcMain.handle("renderer-request-GetInstalledApps", async () => {


### PR DESCRIPTION
@sandeepinigithub , @ratan2020cs131 , @swapnilsparsh , @ksatyarth2 - this is an intermediate fix, it has problems. Could you please help by creating a clean solution?

The bug: Account Details in UI spins forever in Ubuntu 22.04. Both before I am logged in and after I am logged in.

Problems with the current fix:

1. I disabled the spinner at settings-account.vue lines 317-324. With spinner disabled, if I try to open Account Details before logging in - it shows blanks and Invalid Date. However, if I don't disable the spinner and try opening Account Details before logging in - then it spins forever.

Another way to fix it can be to show Account Info icon in the UI only after the user has logged in. If the user is not logged in - then it's better not to show the icon, or it should be gray and not react to clicks.

2. With the spinner disabled, and after I'm logged in - when I open Account Details - I can see blanks and Invalid Date for 1-2 seconds, then it will show my correct account data.

3. After I log out, the UI still shows my account information under Account Details.

