### PR TITLE
Feat/account id settings

### DIFF
--- a/daemon/api/api.go
+++ b/daemon/api/api.go
@@ -416,11 +416,6 @@ func (a *API) SessionNew(emailOrAcctID string, password string) (
 		// Account ID must not have "a-" prefix, per PLCON-52
 		// TODO FIXME: Vlad - for now production backend requires "a-" prefix, and dev backend requires that there's no "a-" prefix
 		acctID := emailOrAcctID
-		if a.currentRestApiBackend != ProductionEnv {
-			acctID = strings.TrimPrefix(acctID, "a-")
-		} else if !strings.HasPrefix(acctID, "a-") {
-			acctID = "a-" + acctID
-		}
 
 		request = &types.SessionNewRequest{
 			AccountID: acctID,

--- a/daemon/api/api.go
+++ b/daemon/api/api.go
@@ -413,12 +413,8 @@ func (a *API) SessionNew(emailOrAcctID string, password string) (
 		}
 		apiPath = _sessionNewPath
 	} else { // passwordless login
-		// Account ID must not have "a-" prefix, per PLCON-52
-		// TODO FIXME: Vlad - for now production backend requires "a-" prefix, and dev backend requires that there's no "a-" prefix
-		acctID := emailOrAcctID
-
 		request = &types.SessionNewRequest{
-			AccountID: acctID,
+			AccountID: strings.TrimPrefix(emailOrAcctID, "a-"), // Account ID must not have "a-" prefix, per PLCON-52
 		}
 		apiPath = _sessionNewPasswordlessPath
 	}

--- a/ui/src/assets/copy.svg
+++ b/ui/src/assets/copy.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="6" y="4" width="10" height="12" rx="2" fill="#8B9AAB" />
+    <rect x="4" y="6" width="10" height="12" rx="2" fill="#8B9AAB" fill-opacity="0.5" />
+</svg>

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -11,6 +11,7 @@
                 :height="'20px'" />
             </div>
             <div v-else-if="$store.state.account.userDetails.id" class="flexColumn">
+              <div class="defColor paramName">Account ID:</div>
               <div
                 style="margin-bottom: 2rem"
                 v-if="this.IsAccIdLogin"
@@ -26,6 +27,7 @@
                 <div
                   @click="toggleAccountIDBlur"
                   style="cursor: pointer; margin-left: 10px"
+                  title="Click to show or hide the account ID"
                 >
                   <div v-if="isAccountIDBlurred">
                     <img
@@ -41,7 +43,7 @@
                   </div>
                 </div>
                 <div style="display: inline-block">
-                  <div style="display: inline-block">
+                  <div style="display: inline-block" title="Copy the account ID">
                     <img
                       style="vertical-align: middle; cursor: pointer"
                       src="@/assets/copy.svg"

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -11,29 +11,67 @@
                 :height="'20px'" />
             </div>
             <div v-else-if="$store.state.account.userDetails.id" class="flexColumn">
-              <img v-if="!profileImage" src="@/assets/avtar.svg" style="height: 100px; width: 100px" />
-              <img v-else :src="profileImage" style="
-                height: 100px;
-                width: 100px;
-                border-radius: 100%;
-                border: 5px solid #fff;
-                margin-bottom: 10px;
-              " />
+              <div
+                style="margin-bottom: 2rem"
+                v-if="this.IsAccIdLogin"
+                class="flexRow paramBlockDetailedConfig"
+                title="Click to show or hide AccountID"
+              >
+                <label
+                  class="settingsBigBoldFont selectable"
+                  :class="{ blurred: isAccountIDBlurred }"
+                >
+                  {{ this.$store.state.account.session.AccountID }}
+                </label>
+                <div
+                  @click="toggleAccountIDBlur"
+                  style="cursor: pointer; margin-left: 10px"
+                >
+                  <div v-if="isAccountIDBlurred">
+                    <img
+                      style="vertical-align: middle"
+                      src="@/assets/eye-close.svg"
+                    />
+                  </div>
+                  <div v-if="!isAccountIDBlurred">
+                    <img
+                      style="vertical-align: middle"
+                      src="@/assets/eye-open.svg"
+                    />
+                  </div>
+                </div>
+                <div style="display: inline-block">
+                  <div style="display: inline-block">
+                    <img
+                      style="vertical-align: middle; cursor: pointer"
+                      src="@/assets/copy.svg"
+                      @click="copyAccountID"
+                      alt="Copy"
+                    />
+                  </div>
+                </div>
+              </div>
 
               <div>
+                <img v-if="!profileImage" src="@/assets/avtar.svg" style="height: 50px; width: 50px" />
+                <img v-else :src="profileImage" style="
+                    height: 50px;
+                    width: 50px;
+                    border-radius: 100%;
+                    border: 5px solid #fff;
+                    margin-bottom: 10px;
+                  " />
+
                 <div class="flexRow paramBlockDetailedConfig">
                   <div class="defColor paramName">Name:</div>
                   <div class="detailedParamValue">
                     {{ $store.state.account.userDetails.name }}
                   </div>
                 </div>
-                <div v-if="this.IsAccIdLogin" class="flexRow paramBlockDetailedConfig">
-                  <div class="defColor paramName">Account ID:</div>
-                  <div class="detailedParamValue">
-                    {{ this.$store.state.account.session.AccountID }}
-                  </div>
-                </div>
-                <div v-if="!this.IsAccIdLogin" class="flexRow paramBlockDetailedConfig">
+                <div
+                  v-if="!this.IsAccIdLogin"
+                  class="flexRow paramBlockDetailedConfig"
+                >
                   <div class="defColor paramName">Email:</div>
                   <div class="detailedParamValue">
                     {{ $store.state.account.userDetails.email }}
@@ -417,6 +455,16 @@ export default {
     },
     UpgradeSubscription() {
       sender.shellOpenExternal(`https://privateline.io/#pricing`);
+    },
+    copyAccountID() {
+      const accountId = this.$store.state.account.session.AccountID;
+      const tempInput = document.createElement("input");
+
+      document.body.appendChild(tempInput);
+      tempInput.value = accountId;
+      tempInput.select();
+      document.execCommand("copy");
+      document.body.removeChild(tempInput);
     },
   },
 };

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -15,7 +15,7 @@
                 style="margin-bottom: 2rem"
                 v-if="this.IsAccIdLogin"
                 class="flexRow paramBlockDetailedConfig"
-                title="Click to show or hide AccountID"
+                title="Click to show or hide the account ID"
               >
                 <label
                   class="settingsBigBoldFont selectable"
@@ -107,7 +107,7 @@
             <!-- <div v-else>Api Error: Data couldn't be fetched at this moment.</div> -->
           </div>
         </div>
-        <div v-if="this.IsSessionInfoReceived && this.IsAccIdLogin" class="overlay-container" style="margin: auto;" @click="toggleAccountIDBlur" title="Click to show or hide QR code">
+        <div v-if="this.IsSessionInfoReceived && this.IsAccIdLogin" class="overlay-container" style="margin: auto;" @click="toggleAccountIDBlur" title="Click to show or hide the account ID QR code">
           <div ref="accIdQrcodePlaceholder" :class="{ blurred: isAccountIDBlurred }"></div>
           <div v-if="isAccountIDBlurred" class="overlay">
             <svg xmlns="http://www.w3.org/2000/svg" width="32" fill="black" viewBox="0 0 512 512">

--- a/ui/src/components/settings/settings-account.vue
+++ b/ui/src/components/settings/settings-account.vue
@@ -16,7 +16,6 @@
                 style="margin-bottom: 2rem"
                 v-if="this.IsAccIdLogin"
                 class="flexRow paramBlockDetailedConfig"
-                title="Click to show or hide the account ID"
               >
                 <label
                   class="settingsBigBoldFont selectable"


### PR DESCRIPTION
Currently if we toggle to see accountID or QR then both will toggle so should I make it separate or keep it like this only.

![image](https://github.com/user-attachments/assets/84545ff9-e3ae-4531-a0ae-43a6d983c0d0)
