### PR TITLE
feat: Profile API update

### DIFF
--- a/daemon/api/api.go
+++ b/daemon/api/api.go
@@ -691,8 +691,17 @@ func (a *API) ProfileData(session string) (
 ) {
 	request := &types.DeviceListRequest{SessionTokenStruct: types.SessionTokenStruct{SessionToken: session}}
 
+	os := runtime.GOOS
+
+	if os == "darwin" {
+		os = "mac"
+	}
+
+	queryParams := fmt.Sprintf("?auth_os=%s&auth_platform=connect", os)
+	fullProfilePath := _profileDataPath + queryParams
+
 	resp = &types.ProfileDataResponse{}
-	if err := a.request(a.getApiHost(), _profileDataPath, "GET", "application/json", request, resp); err != nil {
+	if err := a.request(a.getApiHost(), fullProfilePath, "GET", "application/json", request, resp); err != nil {
 		return nil, 0, err
 	}
 	if resp.HttpStatusCode != types.CodeSuccess {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "privateline-connect-ui",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "productName": "privateline-connect-ui",
   "description": "privateLINE Connect UI Client",
   "author": "PrivateLINE Limited",


### PR DESCRIPTION
@kocmo 	For Windows, we get "windows," and for Linux, we get "linux." However, for macOS, we receive "darwin." That’s why I’m converting "darwin" to "mac," as specified in the API documentation.
