### PR TITLE
fix: items per page size for manage device

### DIFF
--- a/ui/src/components/settings/settings-manage-device.vue
+++ b/ui/src/components/settings/settings-manage-device.vue
@@ -252,7 +252,7 @@ export default {
       searchQuery: "",
       currentPage: 1,
       totalCount: 0,
-      itemsPerPage: 10,
+      itemsPerPage: 5,
       deviceListData: [],
       showDetails: {},
       debounceTimeout: null,


### PR DESCRIPTION
1. Pagination control was hiding when there was 10 result per page. I set it to 5 result.